### PR TITLE
Bugfix/article info child occupy full parent height

### DIFF
--- a/components/Article/index.jsx
+++ b/components/Article/index.jsx
@@ -35,7 +35,7 @@ const Article = ({ title, linkText, imageURL, id, index, animationDelay }) => {
           src={imageURL}
           alt="article thumbnail"
         />
-        <div className="article-info transform -translate-y-1/2 bg-c000 text-center shadow-lg p-6">
+        <div className="article-info transform -translate-y-1/2 bg-c000 text-center shadow-lg">
           <div className="content-info">
             <span className="text-c600 mx-2">
               <i className="fas fa-user-tie mr-1 text-c500"></i>Admin

--- a/components/Article/index.jsx
+++ b/components/Article/index.jsx
@@ -43,7 +43,7 @@ const Article = ({ title, linkText, imageURL, id, index, animationDelay }) => {
             <span className="text-c600 mx-2">
               <i className="fas fa-comments mr-1 text-c500"></i>2 Comments
             </span>
-            <h4 className="text-c100 font-bold">{title}</h4>
+            <h4 className="text-c100 font-bold px-2">{title}</h4>
           </div>
           <div className="block text-c100 text-center spicial-info cursor-pointer">
             <LinkNoPrefetch href={`/${currentLocale}/articles/${id}`}>

--- a/components/Welcome/index.jsx
+++ b/components/Welcome/index.jsx
@@ -141,13 +141,13 @@ const MiniCard = ({ cardInfo }) => {
 };
 
 // card btn
-const WelcomeBtn = ({ link }) => {
+const WelcomeBtn = ({ link :{url,text} }) => {
   const i18n = useI18n();
   const currentLocale = i18n.activeLocale;
   return (
-    <LinkNoPrefetch href={`${currentLocale}/about`}>
+    <LinkNoPrefetch href={`${currentLocale}${url}`}>
       <a className=" btn btn-lg bg-c300 hover:text-c100 inline-block">
-        {link.text}
+        {text}
       </a>
     </LinkNoPrefetch>
   );

--- a/styles/article.css
+++ b/styles/article.css
@@ -3,7 +3,7 @@
 }
 .article .article-info {
   width: 85%;
-  min-height: 150px;
+  height: 150px;
   display: flex;
   margin: 5px auto;
   justify-content: center;


### PR DESCRIPTION
### Description

- changed Height of `article-info` HTML element
- Use the value of `url` from CMS instead of using static one ( Welcome section)